### PR TITLE
Permission check for global chat symbol

### DIFF
--- a/BungeeChatApi/src/main/java/dev/aura/bungeechat/api/BungeeChatApi.java
+++ b/BungeeChatApi/src/main/java/dev/aura/bungeechat/api/BungeeChatApi.java
@@ -8,7 +8,7 @@ import dev.aura.bungeechat.api.utils.BungeeChatInstaceHolder;
 import dev.aura.lib.version.Version;
 import java.io.File;
 
-/** This is the base Interface for the BungeChatApi. The central methods will be found here */
+/** This is the base Interface for the BungeeChatApi. The central methods will be found here */
 public interface BungeeChatApi {
   public static final String ID = "bungeechat";
   public static final String NAME = "Bungee Chat";
@@ -22,7 +22,7 @@ public interface BungeeChatApi {
   public static final String AUTHOR_SHAWN = "shawn_ian";
   public static final String[] AUTHORS = new String[] {AUTHOR_BRAINSTONE, AUTHOR_SHAWN};
   public static final String[] CONTRIBUTORS =
-      new String[] {"MineTech13", "Brianetta", "CryLegend", "gb2233", "n0dai", "Luck"};
+      new String[] {"AwesomestGamer","MineTech13", "Brianetta", "CryLegend", "gb2233", "n0dai", "Luck"};
   public static final String[] TRANSLATORS =
       new String[] {"Maxime_74", "DardBrinza", "gb2233", "Garixer", "povsister"};
   public static final String[] DONATORS = new String[] {"Breantique"};

--- a/src/main/java/dev/aura/bungeechat/listener/GlobalChatListener.java
+++ b/src/main/java/dev/aura/bungeechat/listener/GlobalChatListener.java
@@ -8,6 +8,8 @@ import dev.aura.bungeechat.api.utils.ChatUtils;
 import dev.aura.bungeechat.message.Messages;
 import dev.aura.bungeechat.message.MessagesService;
 import dev.aura.bungeechat.module.BungeecordModuleManager;
+import dev.aura.bungeechat.permission.Permission;
+import dev.aura.bungeechat.permission.PermissionManager;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -63,7 +65,11 @@ public class GlobalChatListener implements Listener {
       if (message.startsWith(symbol) && !symbol.equals("/")) {
         if (!MessagesService.getGlobalPredicate().test(account)) {
           MessagesService.sendMessage(sender, Messages.NOT_IN_GLOBAL_SERVER.get());
+          return;
+        }
 
+        if (!(PermissionManager.hasPermission(sender, Permission.COMMAND_GLOBAL))) {
+          e.setCancelled(true);
           return;
         }
 


### PR DESCRIPTION
Added a permission check to use the prefix (default "!") global chat symbol.