### PR TITLE
Fix message duplication bug

### DIFF
--- a/src/main/java/dev/aura/bungeechat/listener/GlobalChatListener.java
+++ b/src/main/java/dev/aura/bungeechat/listener/GlobalChatListener.java
@@ -69,6 +69,7 @@ public class GlobalChatListener implements Listener {
 
         e.setCancelled(!passToBackendServer);
         MessagesService.sendGlobalMessage(sender, message.substring(1));
+        return;
       }
     }
 


### PR DESCRIPTION
Fix a message duplication bug that happens when the player is writing a message with the global chat symbol in front and the player is in global chat.
Then the message will be send without the global chat symbol and then with the global chat symbol.

----

So when you type in the message `!Test` and you are in `/global` then this would happen:
```
GLOBAL > [Member]Fire_GI: Test
GLOBAL > [Member]Fire_GI: !Test
```