### PR TITLE
Fixed issue #203 by translating color codes when sending the message

### DIFF
--- a/src/main/java/dev/aura/bungeechat/message/MessagesService.java
+++ b/src/main/java/dev/aura/bungeechat/message/MessagesService.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import lombok.Setter;
 import lombok.experimental.UtilityClass;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -445,6 +446,6 @@ public class MessagesService {
   public static void sendMessage(CommandSender recipient, String message) {
     if ((message == null) || message.isEmpty()) return;
 
-    recipient.sendMessage(TextComponent.fromLegacyText(message));
+    recipient.sendMessage(new TextComponent(ChatColor.translateAlternateColorCodes('&', message)));
   }
 }


### PR DESCRIPTION
Fixing #203 Although it is more convenient to use TextComponent.fromLegacyText(), there seems to be a bug in this method that doesn't occur when using ChatColor.translateAlternateColorCodes(). Both methods serve the same purpose, so there shouldn't be any new bugs coming with this fix.